### PR TITLE
fix \u in message

### DIFF
--- a/werobot/client.py
+++ b/werobot/client.py
@@ -4,7 +4,7 @@ import time
 import requests
 
 
-from requests.compat import json
+from requests.compat import json as _json
 from werobot.utils import to_text
 
 
@@ -37,7 +37,10 @@ class Client(object):
         if "params" not in kwargs:
             kwargs["params"] = {"access_token": self.token}
         if isinstance(kwargs.get("data", ""), dict):
-            kwargs["data"] = json.dumps(kwargs["data"])
+            body = _json.dumps(kwargs["data"], ensure_ascii=False)
+            body = body.encode('utf8')
+            kwargs["data"] = body
+
         r = requests.request(
             method=method,
             url=url,


### PR DESCRIPTION
微信比较sb

形如
`{"msgtype": "text", "touser": "111", "text": {"content": "\u4f60\u597d"}}` 的 json

微信会直接显示出 
`\u4f60\u597d` 

这样才能正常工作
`{"msgtype": "text", "touser": "111", "text": {"content": "你好"}}` 
