### PR TITLE
add new message type

### DIFF
--- a/werobot/robot.py
+++ b/werobot/robot.py
@@ -25,7 +25,7 @@ _DEFAULT_CONFIG = dict(
 
 
 class BaseRoBot(object):
-    message_types = ['subscribe', 'unsubscribe', 'click',  # event
+    message_types = ['subscribe', 'unsubscribe', 'click',  'view', # event
                      'text', 'image', 'link', 'location', 'voice']
 
     token = ConfigAttribute("TOKEN")
@@ -130,6 +130,13 @@ class BaseRoBot(object):
             return f
 
         return wraps
+        
+    def view(self, f):
+        """
+        Decorator to add a handler function for ``view event`` messages
+        """
+        self.add_handler(f, type='view')
+        return f
 
     def add_handler(self, func, type='all'):
         """


### PR DESCRIPTION
微信自定义菜单中的链接被点击后会向微信服务发送一个 `view` 类型的事件
参考链接： http://mp.weixin.qq.com/wiki/index.php?title=%E8%87%AA%E5%AE%9A%E4%B9%89%E8%8F%9C%E5%8D%95%E5%88%9B%E5%BB%BA%E6%8E%A5%E5%8F%A3
