### PR TITLE
 imp module deprecated since Python 3.4

### DIFF
--- a/werobot/config.py
+++ b/werobot/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import imp
+import types
 
 
 class ConfigAttribute(object):
@@ -29,7 +29,7 @@ class Config(dict):
         :param filename: 配置文件的文件名
         :return: 如果读取成功，返回 ``True``，如果失败，会抛出错误异常
         """
-        d = imp.new_module('config')
+        d = types.ModuleType('config')
         d.__file__ = filename
         with open(filename) as config_file:
             exec(compile(config_file.read(), filename, 'exec'), d.__dict__)


### PR DESCRIPTION
We can use `types.ModuleType` for all Python versions.