### PR TITLE
增加图文发送接口

### DIFF
--- a/docs/_themes/flask_theme_support.py
+++ b/docs/_themes/flask_theme_support.py
@@ -11,76 +11,68 @@ class FlaskyStyle(Style):
     styles = {
         # No corresponding class for the following:
         #Text:                     "", # class:  ''
-        Whitespace:                "underline #f8f8f8",      # class: 'w'
-        Error:                     "#a40000 border:#ef2929", # class: 'err'
-        Other:                     "#000000",                # class 'x'
-
-        Comment:                   "italic #8f5902", # class: 'c'
-        Comment.Preproc:           "noitalic",       # class: 'cp'
-
-        Keyword:                   "bold #004461",   # class: 'k'
-        Keyword.Constant:          "bold #004461",   # class: 'kc'
-        Keyword.Declaration:       "bold #004461",   # class: 'kd'
-        Keyword.Namespace:         "bold #004461",   # class: 'kn'
-        Keyword.Pseudo:            "bold #004461",   # class: 'kp'
-        Keyword.Reserved:          "bold #004461",   # class: 'kr'
-        Keyword.Type:              "bold #004461",   # class: 'kt'
-
-        Operator:                  "#582800",   # class: 'o'
-        Operator.Word:             "bold #004461",   # class: 'ow' - like keywords
-
-        Punctuation:               "bold #000000",   # class: 'p'
+        Whitespace: "underline #f8f8f8",  # class: 'w'
+        Error: "#a40000 border:#ef2929",  # class: 'err'
+        Other: "#000000",  # class 'x'
+        Comment: "italic #8f5902",  # class: 'c'
+        Comment.Preproc: "noitalic",  # class: 'cp'
+        Keyword: "bold #004461",  # class: 'k'
+        Keyword.Constant: "bold #004461",  # class: 'kc'
+        Keyword.Declaration: "bold #004461",  # class: 'kd'
+        Keyword.Namespace: "bold #004461",  # class: 'kn'
+        Keyword.Pseudo: "bold #004461",  # class: 'kp'
+        Keyword.Reserved: "bold #004461",  # class: 'kr'
+        Keyword.Type: "bold #004461",  # class: 'kt'
+        Operator: "#582800",  # class: 'o'
+        Operator.Word: "bold #004461",  # class: 'ow' - like keywords
+        Punctuation: "bold #000000",  # class: 'p'
 
         # because special names such as Name.Class, Name.Function, etc.
         # are not recognized as such later in the parsing, we choose them
         # to look the same as ordinary variables.
-        Name:                      "#000000",        # class: 'n'
-        Name.Attribute:            "#c4a000",        # class: 'na' - to be revised
-        Name.Builtin:              "#004461",        # class: 'nb'
-        Name.Builtin.Pseudo:       "#3465a4",        # class: 'bp'
-        Name.Class:                "#000000",        # class: 'nc' - to be revised
-        Name.Constant:             "#000000",        # class: 'no' - to be revised
-        Name.Decorator:            "#888",           # class: 'nd' - to be revised
-        Name.Entity:               "#ce5c00",        # class: 'ni'
-        Name.Exception:            "bold #cc0000",   # class: 'ne'
-        Name.Function:             "#000000",        # class: 'nf'
-        Name.Property:             "#000000",        # class: 'py'
-        Name.Label:                "#f57900",        # class: 'nl'
-        Name.Namespace:            "#000000",        # class: 'nn' - to be revised
-        Name.Other:                "#000000",        # class: 'nx'
-        Name.Tag:                  "bold #004461",   # class: 'nt' - like a keyword
-        Name.Variable:             "#000000",        # class: 'nv' - to be revised
-        Name.Variable.Class:       "#000000",        # class: 'vc' - to be revised
-        Name.Variable.Global:      "#000000",        # class: 'vg' - to be revised
-        Name.Variable.Instance:    "#000000",        # class: 'vi' - to be revised
-
-        Number:                    "#990000",        # class: 'm'
-
-        Literal:                   "#000000",        # class: 'l'
-        Literal.Date:              "#000000",        # class: 'ld'
-
-        String:                    "#4e9a06",        # class: 's'
-        String.Backtick:           "#4e9a06",        # class: 'sb'
-        String.Char:               "#4e9a06",        # class: 'sc'
-        String.Doc:                "italic #8f5902", # class: 'sd' - like a comment
-        String.Double:             "#4e9a06",        # class: 's2'
-        String.Escape:             "#4e9a06",        # class: 'se'
-        String.Heredoc:            "#4e9a06",        # class: 'sh'
-        String.Interpol:           "#4e9a06",        # class: 'si'
-        String.Other:              "#4e9a06",        # class: 'sx'
-        String.Regex:              "#4e9a06",        # class: 'sr'
-        String.Single:             "#4e9a06",        # class: 's1'
-        String.Symbol:             "#4e9a06",        # class: 'ss'
-
-        Generic:                   "#000000",        # class: 'g'
-        Generic.Deleted:           "#a40000",        # class: 'gd'
-        Generic.Emph:              "italic #000000", # class: 'ge'
-        Generic.Error:             "#ef2929",        # class: 'gr'
-        Generic.Heading:           "bold #000080",   # class: 'gh'
-        Generic.Inserted:          "#00A000",        # class: 'gi'
-        Generic.Output:            "#888",           # class: 'go'
-        Generic.Prompt:            "#745334",        # class: 'gp'
-        Generic.Strong:            "bold #000000",   # class: 'gs'
-        Generic.Subheading:        "bold #800080",   # class: 'gu'
-        Generic.Traceback:         "bold #a40000",   # class: 'gt'
+        Name: "#000000",  # class: 'n'
+        Name.Attribute: "#c4a000",  # class: 'na' - to be revised
+        Name.Builtin: "#004461",  # class: 'nb'
+        Name.Builtin.Pseudo: "#3465a4",  # class: 'bp'
+        Name.Class: "#000000",  # class: 'nc' - to be revised
+        Name.Constant: "#000000",  # class: 'no' - to be revised
+        Name.Decorator: "#888",  # class: 'nd' - to be revised
+        Name.Entity: "#ce5c00",  # class: 'ni'
+        Name.Exception: "bold #cc0000",  # class: 'ne'
+        Name.Function: "#000000",  # class: 'nf'
+        Name.Property: "#000000",  # class: 'py'
+        Name.Label: "#f57900",  # class: 'nl'
+        Name.Namespace: "#000000",  # class: 'nn' - to be revised
+        Name.Other: "#000000",  # class: 'nx'
+        Name.Tag: "bold #004461",  # class: 'nt' - like a keyword
+        Name.Variable: "#000000",  # class: 'nv' - to be revised
+        Name.Variable.Class: "#000000",  # class: 'vc' - to be revised
+        Name.Variable.Global: "#000000",  # class: 'vg' - to be revised
+        Name.Variable.Instance: "#000000",  # class: 'vi' - to be revised
+        Number: "#990000",  # class: 'm'
+        Literal: "#000000",  # class: 'l'
+        Literal.Date: "#000000",  # class: 'ld'
+        String: "#4e9a06",  # class: 's'
+        String.Backtick: "#4e9a06",  # class: 'sb'
+        String.Char: "#4e9a06",  # class: 'sc'
+        String.Doc: "italic #8f5902",  # class: 'sd' - like a comment
+        String.Double: "#4e9a06",  # class: 's2'
+        String.Escape: "#4e9a06",  # class: 'se'
+        String.Heredoc: "#4e9a06",  # class: 'sh'
+        String.Interpol: "#4e9a06",  # class: 'si'
+        String.Other: "#4e9a06",  # class: 'sx'
+        String.Regex: "#4e9a06",  # class: 'sr'
+        String.Single: "#4e9a06",  # class: 's1'
+        String.Symbol: "#4e9a06",  # class: 'ss'
+        Generic: "#000000",  # class: 'g'
+        Generic.Deleted: "#a40000",  # class: 'gd'
+        Generic.Emph: "italic #000000",  # class: 'ge'
+        Generic.Error: "#ef2929",  # class: 'gr'
+        Generic.Heading: "bold #000080",  # class: 'gh'
+        Generic.Inserted: "#00A000",  # class: 'gi'
+        Generic.Output: "#888",  # class: 'go'
+        Generic.Prompt: "#745334",  # class: 'gp'
+        Generic.Strong: "bold #000000",  # class: 'gs'
+        Generic.Subheading: "bold #800080",  # class: 'gu'
+        Generic.Traceback: "bold #a40000",  # class: 'gt'
     }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,6 @@ pygments_style = 'flask_theme_support.FlaskyStyle'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -99,10 +98,7 @@ html_theme = 'flask'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-  'touch_icon': 'logo.png',
-  'github_url': 'whtsky/WeRoBot'
-}
+html_theme_options = {'touch_icon': 'logo.png', 'github_url': 'whtsky/WeRoBot'}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -139,7 +135,10 @@ html_static_path = ['_static']
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
     'index': ['sidebarintro.html', 'searchbox.html'],
-    '**': ['sidebarintro.html', 'localtoc.html', 'relations.html', 'searchbox.html']
+    '**': [
+        'sidebarintro.html', 'localtoc.html', 'relations.html',
+        'searchbox.html'
+    ]
 }
 
 # Additional templates that should be rendered to pages, maps page names to
@@ -175,25 +174,23 @@ html_sidebars = {
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'WeRoBotdoc'
 
-
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'WeRoBot.tex', u'WeRoBot Documentation',
-   u'whtsky', 'manual'),
+    ('index', 'WeRoBot.tex', u'WeRoBot Documentation', u'whtsky', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -216,19 +213,14 @@ latex_documents = [
 # If false, no module index is generated.
 #latex_domain_indices = True
 
-
 # -- Options for manual page output --------------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', 'werobot', u'WeRoBot Documentation',
-     [u'whtsky'], 1)
-]
+man_pages = [('index', 'werobot', u'WeRoBot Documentation', [u'whtsky'], 1)]
 
 # If true, show URL addresses after external links.
 #man_show_urls = False
-
 
 # -- Options for Texinfo output ------------------------------------------------
 
@@ -236,9 +228,10 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'WeRoBot', u'WeRoBot Documentation',
-   u'whtsky', 'WeRoBot', 'One line description of project.',
-   'Miscellaneous'),
+    (
+        'index', 'WeRoBot', u'WeRoBot Documentation', u'whtsky', 'WeRoBot',
+        'One line description of project.', 'Miscellaneous'
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 import io
 import werobot
+import sys
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1706,3 +1706,251 @@ class TestClientMembersTagClass(BaseTestClass):
         )
         r = self.client.get_tags_by_user(self.user_a_open_id)
         assert r == self.get_tags_by_user_response
+
+
+class TestClientMass(BaseTestClass):
+    UP_NEWS_URL = 'https://api.weixin.qq.com/cgi-bin/media/uploadnews'
+    SEND_ALL_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/sendall'
+    SEND_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/send'
+    DELETE_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/delete'
+    PREVIEW_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/preview'
+    GET_STATUS_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/get'
+    GET_SPEED_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/speed/get'
+    SET_SPEED_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/speed/set'
+
+    articles = [{
+        "thumb_media_id": "qI6_Ze_6PtV7svjolgs-rN6stStuHIjs9_DidOHaj0Q-mwvBelOXCFZiq2OsIU-p",
+        "author": "xxx",
+        "title": "Happy Day",
+        "content_source_url": "www.qq.com",
+        "content": "content",
+        "digest": "digest",
+        "show_cover_pic": 1,
+        "need_open_comment": 1,
+        "only_fans_can_comment": 1
+    },
+        {
+            "thumb_media_id": "qI6_Ze_6PtV7svjolgs-rN6stStuHIjs9_DidOHaj0Q-mwvBelOXCFZiq2OsIU-p",
+            "author": "xxx",
+            "title": "Happy Day",
+            "content_source_url": "www.qq.com",
+            "content": "content",
+            "digest": "digest",
+            "show_cover_pic": 0,
+            "need_open_comment": 1,
+            "only_fans_can_comment": 1
+        }
+    ]
+
+    def up_news_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert body == {"articles": self.articles}
+        return 200, JSON_HEADER, json.dumps({'errcode': 0, 'errmsg': 'ok'})
+
+    def send_all_openid_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert 'touser' in body
+        count = len(body['touser'])
+        assert count >= 2
+        assert count <= 10000
+        assert 'msgtype' in body
+        types = {
+            'mpnews': 'media_id',
+            'mpvideo': 'media_id',
+            'music': 'media_id',
+            'image': 'media_id',
+            'video': 'media_id',
+            'wxcard': 'card_id',
+            'text': 'content',
+        }
+        assert types[body['msgtype']] in body[body['msgtype']]
+        return 200, JSON_HEADER, json.dumps({'errcode': 0, 'errmsg': 'ok'})
+
+    def send_all_tagid_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert 'filter' in body
+        assert 'msgtype' in body
+        types = {
+            'mpnews': 'media_id',
+            'mpvideo': 'media_id',
+            'music': 'media_id',
+            'image': 'media_id',
+            'video': 'media_id',
+            'wxcard': 'card_id',
+            'text': 'content',
+        }
+        assert types[body['msgtype']] in body[body['msgtype']]
+        return 200, JSON_HEADER, json.dumps({'errcode': 0, 'errmsg': 'ok'})
+
+    def delete_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert "msg_id" in body
+        return 200, JSON_HEADER, json.dumps({'errcode': 0, 'errmsg': 'ok'})
+
+    def preview_openid_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert "touser" in body
+        types = {
+            'mpnews': 'media_id',
+            'mpvideo': 'media_id',
+            'music': 'media_id',
+            'image': 'media_id',
+            'video': 'media_id',
+            'wxcard': 'card_id',
+            'text': 'content',
+        }
+        assert types[body['msgtype']] in body[body['msgtype']]
+        return 200, JSON_HEADER, json.dumps({'errcode': 0, 'errmsg': 'ok'})
+
+    def preview_wxname_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert "towxname" in body
+        types = {
+            'mpnews': 'media_id',
+            'mpvideo': 'media_id',
+            'music': 'media_id',
+            'image': 'media_id',
+            'video': 'media_id',
+            'wxcard': 'card_id',
+            'text': 'content',
+        }
+        assert types[body['msgtype']] in body[body['msgtype']]
+        return 200, JSON_HEADER, json.dumps({'errcode': 0, 'errmsg': 'ok'})
+
+    def get_status_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert "msg_id" in body
+        return 200, JSON_HEADER, json.dumps({
+            "msg_id": body['msg_id'],
+            "msg_status": "SEND_SUCCESS"
+        })
+
+    def get_news_speed_callback(self, request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        return 200, JSON_HEADER, json.dumps({
+            "speed": 3,
+            "realspeed": 15
+        })
+
+    def set_news_speed_callback(self,request):
+        params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
+        assert "access_token" in params.keys()
+        body = json.loads(request.body.decode("utf-8"))
+        assert "speed" in body
+        return 200, JSON_HEADER, json.dumps({'errcode': 0, 'errmsg': 'ok'})
+
+    @responses.activate
+    @add_token_response
+    def test_upload_news(self):
+        responses.add_callback(
+            responses.POST,
+            self.UP_NEWS_URL,
+            callback=self.up_news_callback
+        )
+        r = self.client.upload_news(self.articles)
+        assert r == {'errcode': 0, 'errmsg': 'ok'}
+
+    @responses.activate
+    @add_token_response
+    def test_send_by_openid(self):
+        responses.add_callback(
+            responses.POST,
+            self.SEND_URL,
+            callback=self.send_all_openid_callback
+        )
+        r = self.client.send_news_all('mpnews', 'hgbkjnlkmlkn', ['1', '2'], 0)
+        assert r == {'errcode': 0, 'errmsg': 'ok'}
+
+    @responses.activate
+    @add_token_response
+    def test_send_by_tagid(self):
+        responses.add_callback(
+            responses.POST,
+            self.SEND_ALL_URL,
+            callback=self.send_all_tagid_callback
+        )
+        r = self.client.send_news_all('mpnews', 'hgbkjnlkmlkn', 2, 0)
+        assert r == {'errcode': 0, 'errmsg': 'ok'}
+
+    @responses.activate
+    @add_token_response
+    def test_send_all(self):
+        responses.add_callback(
+            responses.POST,
+            self.SEND_ALL_URL,
+            callback=self.send_all_tagid_callback
+        )
+        r = self.client.send_news_all('mpnews', 'hgbkjnlkmlkn', 0, 0)
+        assert r == {'errcode': 0, 'errmsg': 'ok'}
+
+    @responses.activate
+    @add_token_response
+    def test_preview_openid(self):
+        responses.add_callback(
+            responses.POST,
+            self.PREVIEW_URL,
+            callback=self.preview_openid_callback
+        )
+        r = self.client.preview_by_openid('mpnews', 'hgbkjnlkmlkn', 'asdasdasd')
+        assert r == {'errcode': 0, 'errmsg': 'ok'}
+
+    @responses.activate
+    @add_token_response
+    def test_preview_openid(self):
+        responses.add_callback(
+            responses.POST,
+            self.PREVIEW_URL,
+            callback=self.preview_wxname_callback
+        )
+        r = self.client.preview_by_wxname('mpnews', 'hgbkjnlkmlkn', 'asdasdasd')
+        assert r == {'errcode': 0, 'errmsg': 'ok'}
+
+    @responses.activate
+    @add_token_response
+    def test_get_status(self):
+        responses.add_callback(
+            responses.POST,
+            self.GET_STATUS_URL,
+            callback=self.get_status_callback
+        )
+        r = self.client.get_news_status('mpnews')
+        assert 'msg_id' in r
+        assert 'msg_status' in r
+
+    @responses.activate
+    @add_token_response
+    def test_get_speed(self):
+        responses.add_callback(
+            responses.POST,
+            self.GET_SPEED_URL,
+            callback=self.get_news_speed_callback
+        )
+        r = self.client.get_news_speed()
+        assert 'speed' in r
+        assert 'realspeed' in r
+
+    @responses.activate
+    @add_token_response
+    def test_set_speed(self):
+        responses.add_callback(
+            responses.POST,
+            self.SET_SPEED_URL,
+            callback=self.set_news_speed_callback
+        )
+        r = self.client.set_news_speed(1)
+        assert r == {'errcode': 0, 'errmsg': 'ok'}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1718,18 +1718,18 @@ class TestClientMass(BaseTestClass):
     GET_SPEED_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/speed/get'
     SET_SPEED_URL = 'https://api.weixin.qq.com/cgi-bin/message/mass/speed/set'
 
-    articles = [{
-        "thumb_media_id": "qI6_Ze_6PtV7svjolgs-rN6stStuHIjs9_DidOHaj0Q-mwvBelOXCFZiq2OsIU-p",
-        "author": "xxx",
-        "title": "Happy Day",
-        "content_source_url": "www.qq.com",
-        "content": "content",
-        "digest": "digest",
-        "show_cover_pic": 1,
-        "need_open_comment": 1,
-        "only_fans_can_comment": 1
-    },
+    articles = [
         {
+            "thumb_media_id": "qI6_Ze_6PtV7svjolgs-rN6stStuHIjs9_DidOHaj0Q-mwvBelOXCFZiq2OsIU-p",
+            "author": "xxx",
+            "title": "Happy Day",
+            "content_source_url": "www.qq.com",
+            "content": "content",
+            "digest": "digest",
+            "show_cover_pic": 1,
+            "need_open_comment": 1,
+            "only_fans_can_comment": 1
+        }, {
             "thumb_media_id": "qI6_Ze_6PtV7svjolgs-rN6stStuHIjs9_DidOHaj0Q-mwvBelOXCFZiq2OsIU-p",
             "author": "xxx",
             "title": "Happy Day",
@@ -1834,20 +1834,19 @@ class TestClientMass(BaseTestClass):
         assert "access_token" in params.keys()
         body = json.loads(request.body.decode("utf-8"))
         assert "msg_id" in body
-        return 200, JSON_HEADER, json.dumps({
-            "msg_id": body['msg_id'],
-            "msg_status": "SEND_SUCCESS"
-        })
+        return 200, JSON_HEADER, json.dumps(
+            {
+                "msg_id": body['msg_id'],
+                "msg_status": "SEND_SUCCESS"
+            }
+        )
 
     def get_news_speed_callback(self, request):
         params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
         assert "access_token" in params.keys()
-        return 200, JSON_HEADER, json.dumps({
-            "speed": 3,
-            "realspeed": 15
-        })
+        return 200, JSON_HEADER, json.dumps({"speed": 3, "realspeed": 15})
 
-    def set_news_speed_callback(self,request):
+    def set_news_speed_callback(self, request):
         params = urlparse.parse_qs(urlparse.urlparse(request.url).query)
         assert "access_token" in params.keys()
         body = json.loads(request.body.decode("utf-8"))
@@ -1858,9 +1857,7 @@ class TestClientMass(BaseTestClass):
     @add_token_response
     def test_upload_news(self):
         responses.add_callback(
-            responses.POST,
-            self.UP_NEWS_URL,
-            callback=self.up_news_callback
+            responses.POST, self.UP_NEWS_URL, callback=self.up_news_callback
         )
         r = self.client.upload_news(self.articles)
         assert r == {'errcode': 0, 'errmsg': 'ok'}
@@ -1906,7 +1903,9 @@ class TestClientMass(BaseTestClass):
             self.PREVIEW_URL,
             callback=self.preview_openid_callback
         )
-        r = self.client.preview_by_openid('mpnews', 'hgbkjnlkmlkn', 'asdasdasd')
+        r = self.client.preview_by_openid(
+            'mpnews', 'hgbkjnlkmlkn', 'asdasdasd'
+        )
         assert r == {'errcode': 0, 'errmsg': 'ok'}
 
     @responses.activate
@@ -1917,7 +1916,9 @@ class TestClientMass(BaseTestClass):
             self.PREVIEW_URL,
             callback=self.preview_wxname_callback
         )
-        r = self.client.preview_by_wxname('mpnews', 'hgbkjnlkmlkn', 'asdasdasd')
+        r = self.client.preview_by_wxname(
+            'mpnews', 'hgbkjnlkmlkn', 'asdasdasd'
+        )
         assert r == {'errcode': 0, 'errmsg': 'ok'}
 
     @responses.activate

--- a/werobot/client.py
+++ b/werobot/client.py
@@ -22,6 +22,7 @@ def check_error(json):
         raise ClientException("{}: {}".format(json["errcode"], json["errmsg"]))
     return json
 
+
 def _build_send_data(type, content):
     """
     编译群发参数
@@ -32,33 +33,20 @@ def _build_send_data(type, content):
     send_data = {}
     send_data['msgtype'] = type
     if type is 'mpnews' or type is 'voice' or type is 'music' or type is 'image':
-        send_data[type] = {
-            'media_id': content
-        }
+        send_data[type] = {'media_id': content}
     elif type is 'text':
-        send_data[type] = {
-            'media_id': content
-        }
+        send_data[type] = {'media_id': content}
     elif type is 'video':
-        send_data['mpvideo'] = {
-            'media_id': content
-        }
+        send_data['mpvideo'] = {'media_id': content}
         send_data['msgtype'] = 'mpvideo'
     elif type is 'text':
-        send_data['text'] = {
-            'content': content
-        }
+        send_data['text'] = {'content': content}
     elif type is 'wxcard':
-        send_data['wxcard'] = {
-            'card_id': content
-        }
+        send_data['wxcard'] = {'card_id': content}
     else:
-        send_data['text'] = {
-            'content': content
-        }
+        send_data['text'] = {'content': content}
         send_data['msgtype'] = 'text'
     return send_data
-
 
 
 class Client(object):
@@ -1185,7 +1173,9 @@ class Client(object):
             }
         )
 
-    def send_news_all(self, type, content, to=None, send_ignore_reprint=0, clientmsgid=None):
+    def send_news_all(
+        self, type, content, to=None, send_ignore_reprint=0, clientmsgid=None
+    ):
         """
         向指定对象群发信息
         :param type:群发类型，图文消息为mpnews，文本消息为text，语音为voice，音乐为music，图片为image，视频为video，卡券为wxcard
@@ -1211,15 +1201,9 @@ class Client(object):
                     "is_to_all": True,
                 }
             else:
-                send_data['filter'] = {
-                    "is_to_all": False,
-                    "tag_id": to
-                }
+                send_data['filter'] = {"is_to_all": False, "tag_id": to}
 
-        return self.post(
-            url=url,
-            data=send_data
-        )
+        return self.post(url=url, data=send_data)
 
     def delete_news(self, msg_id, article_idx=0):
         """
@@ -1274,9 +1258,7 @@ class Client(object):
         """
         return self.post(
             url="https://api.weixin.qq.com/cgi-bin/message/mass/get",
-            data={
-                'msg_id': msg_id
-            }
+            data={'msg_id': msg_id}
         )
 
     def get_news_speed(self):
@@ -1296,6 +1278,8 @@ class Client(object):
         :return:返回的json
         """
         return self.post(
-            url="https://api.weixin.qq.com/cgi-bin/message/mass/speed/get",
-            data={}
+            url="https://api.weixin.qq.com/cgi-bin/message/mass/speed/set",
+            data={
+                "speed": speed
+            }
         )

--- a/werobot/client.py
+++ b/werobot/client.py
@@ -1279,7 +1279,5 @@ class Client(object):
         """
         return self.post(
             url="https://api.weixin.qq.com/cgi-bin/message/mass/speed/set",
-            data={
-                "speed": speed
-            }
+            data={"speed": speed}
         )

--- a/werobot/client.py
+++ b/werobot/client.py
@@ -22,6 +22,44 @@ def check_error(json):
         raise ClientException("{}: {}".format(json["errcode"], json["errmsg"]))
     return json
 
+def _build_send_data(type, content):
+    """
+    编译群发参数
+    :param type:群发类型，图文消息为mpnews，文本消息为text，语音为voice，音乐为music，图片为image，视频为video，卡券为wxcard
+    :param content: 群发内容
+    :return: 群发参数
+    """
+    send_data = {}
+    send_data['msgtype'] = type
+    if type is 'mpnews' or type is 'voice' or type is 'music' or type is 'image':
+        send_data[type] = {
+            'media_id': content
+        }
+    elif type is 'text':
+        send_data[type] = {
+            'media_id': content
+        }
+    elif type is 'video':
+        send_data['mpvideo'] = {
+            'media_id': content
+        }
+        send_data['msgtype'] = 'mpvideo'
+    elif type is 'text':
+        send_data['text'] = {
+            'content': content
+        }
+    elif type is 'wxcard':
+        send_data['wxcard'] = {
+            'card_id': content
+        }
+    else:
+        send_data['text'] = {
+            'content': content
+        }
+        send_data['msgtype'] = 'text'
+    return send_data
+
+
 
 class Client(object):
     """
@@ -1120,4 +1158,144 @@ class Client(object):
                 "openid_list": open_id_list,
                 "tagid": tag_id
             }
+        )
+
+    def upload_news(self, articles):
+        """
+        上传图文消息素材
+        具体请参考:https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Batch_Sends_and_Originality_Checks.html#1
+        articles = [{
+                    "thumb_media_id":"qI6_Ze_6PtV7svjolgs-rN6stStuHIjs9_DidOHaj0Q-mwvBelOXCFZiq2OsIU-p",
+                    "author":"xxx",
+                    "title":"Happy Day",
+                    "content_source_url":"www.qq.com",
+                    "content":"content",
+                    "digest":"digest",
+                    "show_cover_pic":1,
+                    "need_open_comment":1,
+                    "only_fans_can_comment":1
+                }]
+        :param articles:上传的图文消息数据
+        :return:
+        """
+        return self.post(
+            url="https://api.weixin.qq.com/cgi-bin/media/uploadnews",
+            data={
+                "articles": articles,
+            }
+        )
+
+    def send_news_all(self, type, content, to=None, send_ignore_reprint=0, clientmsgid=None):
+        """
+        向指定对象群发信息
+        :param type:群发类型，图文消息为mpnews，文本消息为text，语音为voice，音乐为music，图片为image，视频为video，卡券为wxcard
+        :param content: 群发内容
+        :param to: 发送对象，None代表全部，整型代表用户组，列表代表指定用户
+        :param send_ignore_reprint: 图文消息被判定为转载时，是否继续群发。 1为继续群发（转载），0为停止群发。 该参数默认为0。
+        :param clientmsgid: 群发时，微信后台将对 24 小时内的群发记录进行检查，如果该 clientmsgid 已经存在一条群发记录，则会拒绝本次群发请求，返回已存在的群发msgid
+        :return:
+        """
+        send_data = _build_send_data(type, content)
+        send_data['send_ignore_reprint'] = send_ignore_reprint
+        if not clientmsgid is None:
+            if len(clientmsgid) > 64:
+                clientmsgid = clientmsgid[0:64]
+            send_data['clientmsgid'] = clientmsgid
+        if isinstance(to, list):
+            url = 'https://api.weixin.qq.com/cgi-bin/message/mass/send'
+            send_data['touser'] = to
+        else:
+            url = 'https://api.weixin.qq.com/cgi-bin/message/mass/sendall'
+            if None is to:
+                send_data['filter'] = {
+                    "is_to_all": True,
+                }
+            else:
+                send_data['filter'] = {
+                    "is_to_all": False,
+                    "tag_id": to
+                }
+
+        return self.post(
+            url=url,
+            data=send_data
+        )
+
+    def delete_news(self, msg_id, article_idx=0):
+        """
+        群发之后，随时可以通过该接口删除群发。
+        :param msg_id:发送出去的消息ID
+        :param article_idx:要删除的文章在图文消息中的位置，第一篇编号为1，该字段不填或填0会删除全部文章
+        :return:微信返回的json数据
+        """
+        return self.post(
+            url="https://api.weixin.qq.com/cgi-bin/message/mass/delete",
+            data={
+                "msg_id": msg_id,
+                "article_idx": article_idx
+            }
+        )
+
+    def preview_by_openid(self, type, content, openid):
+        """
+        开发者可通过该接口发送消息给指定用户，在手机端查看消息的样式和排版。为了满足第三方平台开发者的需求，在保留对openID预览能力的同时，增加了对指定微信号发送预览的能力，但该能力每日调用次数有限制（100次），请勿滥用。
+        :param type:发送类型，图文消息为mpnews，文本消息为text，语音为voice，音乐为music，图片为image，视频为video，卡券为wxcard
+        :param content:预览内容
+        :param openid:预览用户
+        :return:返回的json
+        """
+        send_data = _build_send_data(type, content)
+        send_data['touser'] = openid
+        return self.post(
+            url="https://api.weixin.qq.com/cgi-bin/message/mass/preview",
+            data=send_data
+        )
+
+    def preview_by_wxname(self, type, content, wxname):
+        """
+        开发者可通过该接口发送消息给指定用户，在手机端查看消息的样式和排版。为了满足第三方平台开发者的需求，在保留对openID预览能力的同时，增加了对指定微信号发送预览的能力，但该能力每日调用次数有限制（100次），请勿滥用。
+        :param type:发送类型，图文消息为mpnews，文本消息为text，语音为voice，音乐为music，图片为image，视频为video，卡券为wxcard
+        :param content:预览内容
+        :param wxname:预览用户
+        :return:返回的json
+        """
+        send_data = _build_send_data(type, content)
+        send_data['towxname'] = wxname
+        return self.post(
+            url="https://api.weixin.qq.com/cgi-bin/message/mass/preview",
+            data=send_data
+        )
+
+    def get_news_status(self, msg_id):
+        """
+        查询群发消息发送状态
+        :param msg_id:群发消息后返回的消息id
+        :return:返回的json
+        """
+        return self.post(
+            url="https://api.weixin.qq.com/cgi-bin/message/mass/get",
+            data={
+                'msg_id': msg_id
+            }
+        )
+
+    def get_news_speed(self):
+        """
+        获取群发级别
+        :return:
+        """
+        return self.post(
+            url="https://api.weixin.qq.com/cgi-bin/message/mass/speed/get",
+            data={}
+        )
+
+    def set_news_speed(self, speed):
+        """
+        控制群发速度
+        :param speed:群发速度的级别，是一个0到4的整数，数字越大表示群发速度越慢。
+        :return:返回的json
+        """
+        return self.post(
+            url="https://api.weixin.qq.com/cgi-bin/message/mass/speed/get",
+            data={}
         )


### PR DESCRIPTION
上传图文消息素材【订阅号与服务号认证后均可用】
根据标签进行群发【订阅号与服务号认证后均可用】
根据OpenID列表群发【订阅号不可用，服务号认证后可用】
删除群发【订阅号与服务号认证后均可用】
预览接口【订阅号与服务号认证后均可用】
查询群发消息发送状态【订阅号与服务号认证后均可用】
事件推送群发结果
使用 clientmsgid 参数，避免重复推送
控制群发速度
<!--
在发布 Pull Request 之前，请花一点时间读一下我们的贡献指南：
https://werobot.readthedocs.io/zh_CN/master/contribution-guide.html
-->
