### PR TITLE
增加了微信模板回调的实现，麻烦合并 templatesendjobfinish_event 分支请求

### DIFF
--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -89,6 +89,7 @@ WeRoBot会将合法的请求发送给 handlers 依次执行。
 :func:`robot.update_member_card <werobot.robot.BaseRoBot.update_member_card>`                               会员卡积分余额发生变动 (Event)
 :func:`robot.card_sku_remind <werobot.robot.BaseRoBot.card_sku_remind>`                                     库存警告 (Event)
 :func:`robot.card_pay_order <werobot.robot.BaseRoBot.card_pay_order>`                                       券点发生变动 (Event)
+:func:`robot.templatesendjobfinish_event <werobot.robot.BaseRoBot.templatesendjobfinish_event>`             模板信息推送事件 (Event)
 :func:`robot.submit_membercard_user_info <werobot.robot.BaseRoBot.submit_membercard_user_info>`             激活卡券 (Event)
 :func:`robot.location_event <werobot.robot.BaseRoBot.location_event>`                                       上报位置 (Event)
 :func:`robot.unknown_event <werobot.robot.BaseRoBot.unknown_event>`                                         未知类型 (Event)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -675,6 +675,31 @@ def test_submit_membercard_user_info_handler():
     assert reply._args['content'] == u'现在醒一醒还来得及'
 
 
+def test_templatesendjobfinish_event_handler():
+    @werobot.templatesendjobfinish_event
+    def templatesendjobfinish_event():
+        return '喵喵~模板消息已经推送'
+
+    message = parse_user_msg(
+        """
+            <xml>
+                <ToUserName><![CDATA[gh_7f083739789a]]></ToUserName>
+                <FromUserName><![CDATA[oia2TjuEGTNoeX76QEjQNrcURxG8]]></FromUserName>
+                <CreateTime>1395658920</CreateTime>
+                <MsgType><![CDATA[event]]></MsgType>
+                <Event><![CDATA[TEMPLATESENDJOBFINISH]]></Event>
+                <MsgID>200163836</MsgID>
+                <Status><![CDATA[success]]></Status>
+            </xml>
+        """
+    )
+
+    reply = werobot.get_reply(message)
+
+    assert isinstance(reply, TextReply)
+    assert reply._args['content'] == u'喵喵~模板消息已经推送'
+
+
 def test_unknown_event():
     @werobot.unknown_event
     def unknown_event(message):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -862,7 +862,7 @@ def test_location_event():
     assert message.precision == 119.385040
 
 
-def test_template_send_job_finish_event():
+def test_templatesendjobfinish_event():
     message = parse_user_msg(
         """
     <xml>

--- a/werobot/robot.py
+++ b/werobot/robot.py
@@ -79,6 +79,7 @@ class BaseRoBot(object):
         'update_member_card_event',
         'card_sku_remind_event',
         'card_pay_order_event',
+        'templatesendjobfinish_event',
         'submit_membercard_user_info_event',  # event
         'text',
         'image',
@@ -453,6 +454,12 @@ class BaseRoBot(object):
         事件添加一个 handler 方法的装饰器。
         """
         self.add_handler(f, type='submit_membercard_user_info_event')
+        return f
+
+    def templatesendjobfinish_event(self, f):
+        """在模版消息发送任务完成后，微信服务器会将是否送达成功作为通知，发送到开发者中心中填写的服务器配置地址中
+        """
+        self.add_handler(f, type='templatesendjobfinish_event')
         return f
 
     def unknown_event(self, f):


### PR DESCRIPTION
此 PR 是针对 #541  问题的处理
<!--
在发布 Pull Request 之前，请花一点时间读一下我们的贡献指南：
https://werobot.readthedocs.io/zh_CN/master/contribution-guide.html
-->
微信公众号（服务号）在调用 Client 发送模板信息后，微信会将该模板信息的推送到用户微信并向开发者的服务器发送其模板信息推送的结果，详情见 [公众号文档/模板消息](https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Template_Message_Interface.html#6)

werobot 在处理该类事件的时候，虽然 `werobot.messages.events` 已经存在这个 event，但是并没有将其增加到 `BaseRoBot.message_types` 并且加入到 `BaseRoBot` 里面

我参考微信官方文档，按照 WeRoBot 的代码习惯增加代码部分实现如下：

- `BaseRoBot.message_types`  增加 `templatesendjobfinish_event` 的引用
-  `BaseRoBot`  增加方法 `templatesendjobfinish_event`

测试部分增加/修改细节如下：
- `test_parser.py` 里 `templatesendjobfinish_event` 测试改了个名字
- `test_handler.py` 增加 `templatesendjobfinish_event` 的调用测试

文档部分因为增加 `templatesendjobfinish_event` 调整如下
- `docs/handlers.rst` 的表格中增加 `templatesendjobfinish_event` 事件的说明

测试说明：
- 连回公司搞了个PY3.8 的环境测试了一下没有问题
- 其他 python 版本有待 CI 的进一步测试
- 文档的继承根据 rst 格式编写，也没有测试过

 以上~
