### PR TITLE
bugfix: corrected XML parsing error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import werobot
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
+import sys
 
 
 class PyTest(TestCommand):

--- a/werobot/client.py
+++ b/werobot/client.py
@@ -52,6 +52,7 @@ class Client(object):
     微信 API 操作类
     通过这个类可以方便的通过微信 API 进行一系列操作，比如主动发送消息、创建自定义菜单等
     """
+
     def __init__(self, config):
         self.config = config
         self._token = None
@@ -357,8 +358,7 @@ class Client(object):
         :return: 返回的 JSON 数据包
         """
         return self.post(
-            url=
-            "http://api.weixin.qq.com/customservice/kfaccount/uploadheadimg",
+            url="http://api.weixin.qq.com/customservice/kfaccount/uploadheadimg",
             params={
                 "access_token": self.token,
                 "kf_account": account

--- a/werobot/parser.py
+++ b/werobot/parser.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import re
 import xmltodict
 from werobot.messages.messages import MessageMetaClass, UnknownMessage
 from werobot.messages.events import EventMetaClass, UnknownEvent
@@ -11,7 +12,8 @@ def parse_user_msg(xml):
 
 
 def parse_xml(text):
-    xml_dict = xmltodict.parse(text)["xml"]
+    text_clean = re.sub(b'[\x00-\x09\x0B-\x0C\x0E-\x1F]', b'', text)
+    xml_dict = xmltodict.parse(text_clean)["xml"]
     xml_dict["raw"] = text
     return xml_dict
 


### PR DESCRIPTION
<!--
在发布 Pull Request 之前，请花一点时间读一下我们的贡献指南：
https://werobot.readthedocs.io/zh_CN/master/contribution-guide.html
-->‘
Fix #420
微信对\x00-\x1F这些字符没有很好转义，导致输入的微信消息存在部分控制字符时 xmltodict.parse 100%报错，然后系统崩溃。这个pull request能够很好地修复这个问题。